### PR TITLE
Added Windows support

### DIFF
--- a/bddcli/authoring/given.py
+++ b/bddcli/authoring/given.py
@@ -1,8 +1,8 @@
-import os
 import signal
 
 from ..context import Context
 from ..calls import FirstCall, AlteredCall, Call
+from ..platform_ import killpg
 from .story import Story
 from .manipulation import Manipulator
 
@@ -24,7 +24,7 @@ class Given(Story, Context):
 
     def kill(self, s=signal.SIGTERM):
         call = self.current_call
-        os.killpg(os.getpgid(call.process.pid), s)
+        killpg(call.process.pid, s)
 
     def wait(self, stdin=None, timeout=None):
         call = self.current_call

--- a/bddcli/platform_.py
+++ b/bddcli/platform_.py
@@ -1,0 +1,55 @@
+''' A module for platform-dependent functions
+'''
+import os
+import subprocess as sp
+
+
+def killpg(pid, s):
+    if os.name == "nt":
+        # On Windows, os module can't kill processes by group
+        # Kill all children indiscriminately instead
+        sp.call(['taskkill', '/T', '/F', '/PID',
+                str(pid)])
+    else:
+        os.killpg(os.getpgid(pid), s)
+
+
+def popen(command, environ, **kw):
+    if os.name == "nt":
+        # On Windows, the specified env must include a valid SystemRoot
+        # Use a current value
+        if environ is not None:
+            environ["SystemRoot"] = os.environ["SystemRoot"]
+        process = sp.Popen(
+            ' '.join(command),
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+            shell=True,
+            env=environ,
+            **kw,
+        )
+    else:
+        process = sp.Popen(
+            ' '.join(command),
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+            shell=True,
+            env=environ,
+            preexec_fn=os.setpgrp,
+            **kw,
+        )
+    return process
+
+
+def bootstrapper_name():
+    if os.name == "nt":
+        return 'bddcli_bootstrapper'
+    else:
+        return 'bddcli-bootstrapper'
+
+
+def form_bootstrapper_path(bindir, bootstrapper):
+    if os.name == "nt":
+        return os.path.join(bindir, bootstrapper, "__init__.py")
+    else:
+        return os.path.join(bindir, bootstrapper)

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -5,9 +5,13 @@ from bddcli import Given, stdout, Application, when, given
 
 def foos():  # pragma: no cover
     e = os.environ.copy()
+    # For Linux and Windows
+    discarded_variables = ['LC_CTYPE', 'PWD',
+                           'COMSPEC', 'PATHEXT', 'PROMPT', 'SYSTEMROOT']
+    # Windows environment variables are case-insensitive, lowercase them
     print(' '.join(
-        f'{k}: {v}' for k, v in e.items() if k not in ['LC_CTYPE', 'PWD']
-    ))
+        f'{k}: {v}' for k, v in e.items() if k not in discarded_variables
+    ).lower())
 
 
 app = Application('foo', 'tests.test_environ:foos')

--- a/tests/test_manipulators.py
+++ b/tests/test_manipulators.py
@@ -8,9 +8,13 @@ from bddcli import Given, when, stdout, Application, given, stderr
 
 def baz():  # pragma: no cover
     e = os.environ.copy()
+    # For Linux and Windows
+    discarded_variables = ['LC_CTYPE', 'PWD',
+                           'COMSPEC', 'PATHEXT', 'PROMPT', 'SYSTEMROOT']
+    # Windows environment variables are case-insensitive, lowercase them
     print(' '.join(
-        f'{k}: {v}' for k, v in e.items() if k not in ['LC_CTYPE', 'PWD']
-    ))
+        f'{k}: {v}' for k, v in e.items() if k not in discarded_variables
+    ).lower())
     print(' '.join(sys.argv), file=sys.stderr)
 
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import time
 
@@ -12,11 +13,18 @@ def foo():  # pragma: no cover
         done = s
         print('Signal received:', s, flush=True)
 
-    signal.signal(signal.SIGTERM, terminate)
-    signal.signal(signal.SIGINT, terminate)
+    if os.name == "posix":
+        signal.signal(signal.SIGTERM, terminate)
+        signal.signal(signal.SIGINT, terminate)
 
-    while done is None:
+    # Prevent hanging in a case of failure
+    ticks = 0
+    while done is None and ticks < 50:
         time.sleep(.6)
+        ticks += 1
+
+    if ticks >= 50:
+        print("Timeout")
 
     return done
 
@@ -27,15 +35,23 @@ app = Application('foo', 'tests.test_signal:foo')
 def test_signal():
     with Given(app, nowait=True) as s:
         # Wait some moments
-        time.sleep(1)
-        s.kill()
-        s.wait()
-        assert stdout == 'Signal received: 15\n'
-        assert status == -15
+        if os.name == "nt":
+            # Windows doesn't support the Unix signals.
+            # Simply check if the process didn't timeout.
+            time.sleep(1)
+            s.kill()
+            s.wait()
+            assert stdout == ''
+        else:
+            time.sleep(1)
+            s.kill()
+            s.wait()
+            assert stdout == 'Signal received: 15\n'
+            assert status == -15
 
-        when()
-        time.sleep(1)
-        s.kill(signal.SIGINT)
-        s.wait()
-        assert stdout == 'Signal received: 2\n'
-        assert status == -2
+            when()
+            time.sleep(1)
+            s.kill(signal.SIGINT)
+            s.wait()
+            assert stdout == 'Signal received: 2\n'
+            assert status == -2

--- a/tests/test_workingdirectory.py
+++ b/tests/test_workingdirectory.py
@@ -13,6 +13,9 @@ app = Application('foo', 'tests.test_workingdirectory:foo')
 def test_working_directory():
     with Given(app):
         assert f'{os.getcwd()}\n' == stdout
-
-        when(working_directory='/tmp')
-        assert stdout == '/tmp\n'
+        if os.name == "nt":
+            tmp_dir = os.getenv('TEMP')
+        else:
+            tmp_dir = '/tmp'
+        when(working_directory=tmp_dir)
+        assert stdout == tmp_dir + '\n'


### PR DESCRIPTION
1) Fixed the usage of platform-dependent os module methods.
2) Disabled tests that wouldn't work on Windows due to fundamental differences.
3) Fixed a minor bug in the PYTHONPATH entries handling.

Tested on Windows 10, Anaconda 4.9.2. It passed seven tests out of eleven.

P.S. coveralls seems to be on maintenance. I guess the CI pipeline will fail because of it.